### PR TITLE
Update git url in Gemfile to use https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org"
 
-gem 'omniauth-gds', :git => 'git@github.com:alphagov/omniauth-gds.git'
+gem 'omniauth-gds', :git => 'https://github.com/alphagov/omniauth-gds.git'
 gem 'kibana', :git => 'https://github.com/alphagov/Kibana.git', :branch => 'kibana-ruby'
 gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: git@github.com:alphagov/omniauth-gds.git
-  revision: 147d3a53897c51917642b5811244070107daa9c8
-  specs:
-    omniauth-gds (0.0.3)
-      omniauth-oauth2 (~> 1.0)
-
-GIT
   remote: https://github.com/alphagov/Kibana.git
   revision: 90ce2c3ce5d3df3b3ee2135554d1c488607c1e84
   branch: kibana-ruby
@@ -17,6 +10,13 @@ GIT
       sinatra
       thin
       tzinfo
+
+GIT
+  remote: https://github.com/alphagov/omniauth-gds.git
+  revision: 147d3a53897c51917642b5811244070107daa9c8
+  specs:
+    omniauth-gds (0.0.3)
+      omniauth-oauth2 (~> 1.0)
 
 GEM
   remote: http://rubygems.org/


### PR DESCRIPTION
Using the SSH protocol in GitHub URLs creates pain on deployment as it requires SSH keys which we can't give to GitHub in a nice fashion. It might also not be allowed out through vendor firewalls without pain, too. 
Using the HTTPS URL works much better, making for simpler deployments.

Thanks @alext :)
