### PR TITLE
Bump omniauth-gds to 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
-gem 'omniauth-gds', :git => 'https://github.com/alphagov/omniauth-gds.git'
+gem 'omniauth-gds', '~> 3.1'
 gem 'kibana-rack'
 gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,36 @@
-GIT
-  remote: https://github.com/alphagov/omniauth-gds.git
-  revision: 147d3a53897c51917642b5811244070107daa9c8
-  specs:
-    omniauth-gds (0.0.3)
-      omniauth-oauth2 (~> 1.0)
-
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     backports (3.6.0)
-    faraday (0.8.5)
-      multipart-post (~> 1.1)
-    hashie (1.2.0)
-    httpauth (0.2.0)
-    jwt (0.1.5)
-      multi_json (>= 1.0)
+    faraday (0.9.0)
+      multipart-post (>= 1.2, < 3)
+    hashie (3.2.0)
+    jwt (1.0.0)
     kgio (2.8.0)
     kibana-rack (0.1.0)
       faraday
       sinatra
       sinatra-contrib
-    multi_json (1.6.1)
-    multipart-post (1.1.5)
-    oauth2 (0.8.1)
-      faraday (~> 0.8)
-      httpauth (~> 0.1)
-      jwt (~> 0.1.4)
-      multi_json (~> 1.0)
+    multi_json (1.10.1)
+    multi_xml (0.5.5)
+    multipart-post (2.0.0)
+    oauth2 (1.0.0)
+      faraday (>= 0.8, < 0.10)
+      jwt (~> 1.0)
+      multi_json (~> 1.3)
+      multi_xml (~> 0.5)
       rack (~> 1.2)
-    omniauth (1.1.3)
-      hashie (~> 1.2)
-      rack
-    omniauth-oauth2 (1.1.1)
-      oauth2 (~> 0.8.0)
-      omniauth (~> 1.0)
+    omniauth (1.2.2)
+      hashie (>= 1.2, < 4)
+      rack (~> 1.0)
+    omniauth-gds (3.1.0)
+      multi_json (~> 1.10)
+      omniauth-oauth2 (~> 1.0)
+    omniauth-oauth2 (1.2.0)
+      faraday (>= 0.8, < 0.10)
+      multi_json (~> 1.3)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
     rack (1.5.2)
     rack-protection (1.5.3)
       rack
@@ -62,6 +59,6 @@ PLATFORMS
 
 DEPENDENCIES
   kibana-rack
-  omniauth-gds!
+  omniauth-gds (~> 3.1)
   rack-test
   unicorn


### PR DESCRIPTION
This is necessary to ensure that auth continues to work when the token
validation in signon is tightened up. See
https://github.com/alphagov/signonotron2/pull/245 for more details.
