### PR TITLE
Upgrade to kibana-rack 0.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     jwt (0.1.5)
       multi_json (>= 1.0)
     kgio (2.8.0)
-    kibana-rack (0.1.0)
+    kibana-rack (0.1.1)
       faraday
       sinatra
       sinatra-contrib


### PR DESCRIPTION
This upgrades kibana-rack and ensures that the dashboard endpoint returns the correct content-type, which [the author says is an important fix](https://twitter.com/tabolario/status/498831338011508736)

See [compare url](https://github.com/tabolario/kibana-rack/compare/v0.1.0...v0.1.1)
