### PR TITLE
Upgrade Rack to 1.5.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem 'omniauth-gds', '~> 3.1'
 gem 'kibana-rack'
 gem 'unicorn'
+gem 'rack', '1.5.4'
 
 group :development do
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       multi_json (~> 1.3)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    rack (1.5.2)
+    rack (1.5.4)
     rack-protection (1.5.3)
       rack
     rack-test (0.6.2)
@@ -60,5 +60,6 @@ PLATFORMS
 DEPENDENCIES
   kibana-rack
   omniauth-gds (~> 3.1)
+  rack (= 1.5.4)
   rack-test
   unicorn


### PR DESCRIPTION
Rack 1.5.4 is unaffected by a denial of service vulnerability (CVE-2015-3225).

https://groups.google.com/d/msg/rubyonrails-security/gcUbICUmKMc/qiCotVZwXrMJ