### PR TITLE
Exclude cdn-logs-monitor app from dashboard

### DIFF
--- a/dashboards/top_10_erroring_apps.json
+++ b/dashboards/top_10_erroring_apps.json
@@ -4,7 +4,7 @@
     "query": {
       "list": {
         "0": {
-          "query": "@fields.status: [500 TO 599] AND NOT @tags:nginx",
+          "query": "@fields.status: [500 TO 599] AND NOT @tags:nginx AND NOT @fields.application:\"govuk-cdn-logs-monitor\"",
           "alias": "",
           "color": "#7EB26D",
           "id": 0,


### PR DESCRIPTION
The `govuk-cdn-logs-monitor` app records all HTTP responses served from
the CDN edge, so we should exclude it from this dashboard as it would
otherwise skew the results (and `govuk-cdn-logs-monitor` would appear as
the app generating the most 5XX errors).

Before:

[![screen shot 2016-01-20 at 18 27 34](https://cloud.githubusercontent.com/assets/4348848/12458808/7f6b472e-bfa3-11e5-9a0b-9844fc64e83b.png)](https://kibana.publishing.service.gov.uk/kibana#/dashboard/file/top_10_erroring_apps.json)

After:

![screen shot 2016-01-20 at 18 28 23](https://cloud.githubusercontent.com/assets/4348848/12458827/9f0659b6-bfa3-11e5-8c6a-d835d9e6c1de.png)

/cc @rboulton