### PR TITLE
Allow terms panel to be edited

### DIFF
--- a/dashboards/top_10_erroring_apps.json
+++ b/dashboards/top_10_erroring_apps.json
@@ -46,7 +46,7 @@
         {
           "error": false,
           "span": 12,
-          "editable": false,
+          "editable": true,
           "type": "terms",
           "loadingEditor": false,
           "field": "@fields.application",


### PR DESCRIPTION
It's useful to be able to edit this panel so that changes can be made to
improve it. Editing panels in the Kibana UI is often easier when you
want to try something out quickly.