### PR TITLE
Exclude router from list of erroring apps

### DIFF
--- a/dashboards/top_10_erroring_apps.json
+++ b/dashboards/top_10_erroring_apps.json
@@ -4,7 +4,7 @@
     "query": {
       "list": {
         "0": {
-          "query": "@fields.status: [500 TO 599] AND NOT @tags:nginx AND NOT @fields.application:\"govuk-cdn-logs-monitor\"",
+          "query": "@fields.status: [500 TO 599] AND @tags:application AND NOT @fields.application:\"govuk-cdn-logs-monitor\"",
           "alias": "",
           "color": "#7EB26D",
           "id": 0,


### PR DESCRIPTION
Exclude the `router` application from the list of erroring apps. The
router acts as a reverse proxy for all requests to all other
applications, so it's not useful to show it in this dashboard.

Do this by changing the query to only use logs that are tagged with
`application`, which excludes logs from the router.

I also think this is more eloquent than using all logs not tagged
`nginx`.