### PR TITLE
Add test-unit to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ gem 'raindrops', '>= 0.13.0'
 
 group :development do
   gem 'rack-test'
+  gem 'test-unit'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
       multi_json (~> 1.3)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
+    power_assert (0.2.6)
     rack (1.5.4)
     rack-protection (1.5.3)
       rack
@@ -48,6 +49,8 @@ GEM
       rack-test
       sinatra (~> 1.4.0)
       tilt (~> 1.3)
+    test-unit (3.1.5)
+      power_assert
     tilt (1.4.1)
     unicorn (4.6.1)
       kgio (~> 2.6)
@@ -64,7 +67,8 @@ DEPENDENCIES
   rack (= 1.5.4)
   rack-test
   raindrops (>= 0.13.0)
+  test-unit
   unicorn
 
 BUNDLED WITH
-   1.10.6
+   1.11.2


### PR DESCRIPTION
Ruby 2.3 doesn't bundle `test/unit`.