### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rack', '1.5.4'
 gem 'kgio', '>= 2.9.2'
 gem 'raindrops', '>= 0.13.0'
 
-group :development do
+group :test do
   gem 'rack-test'
   gem 'test-unit'
 end

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,42 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'kibana-gds'
+GOVUK_APP_NAME = 'kibana'
+
+node {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  try {
+    stage("Checkout") {
+      checkout scm
+    }
+
+    stage("Install dependencies") {
+      govuk.bundleApp()
+    }
+
+    stage("Tests") {
+      sh "bundle exec ruby test/test_authwrapper.rb"
+    }
+
+    if (env.BRANCH_NAME == 'master') {
+      stage("Push release tag") {
+        govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
+      }
+
+      stage("Deploy to integration") {
+        build job: 'integration-app-deploy',
+        parameters: [string(name: GOVUK_APP_NAME, value: 'release_' + env.BUILD_NUMBER)]
+      }
+    }
+
+  } catch (e) {
+    currentBuild.result = "FAILED"
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+
+}

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-set -eu
-
-bundle install --quiet --path "${HOME}/bundles/${JOB_NAME}" --deployment
-exec bundle exec ruby test/test_authwrapper.rb


### PR DESCRIPTION
The new Jenkins for GOV.UK builds with a Jenkinsfile.

I've modified the Gemfile because the standard bundle for Jenkins now runs `--without development`.

After merging we'll need to adjust the build number:

```
def job = Jenkins.instance.getItemByFullName("kibana/master")
job.nextBuildNumber = 50
job.save()
```
